### PR TITLE
SimilarManager()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,32 @@ Adds a new query set filter keyword to allow text searching.
 
     MyModel.objects.filter(field_name__similar='whatever')
 
-To ensure results ordered by similarity, try this:
+To ensure results ordered by similarity, you could do this:
 
     MyModel.objects.filter(field_name__similar='whatever').
                       extra(select={'distance': "similarity(name, 'whatever')"}).
                       order_by('-distance'))
+
+In a sake of brevity, you could use a provided `SimilarManager` that has a `filter_o`
+method.
+
+    from djorm_pgtrgm import SimilarManager
+
+    class MyModel(models.Model):
+        objects = SimilarManager()
+
+        # your fields
+        ...
+
+`filter_o` is a shortcut for the `filter + extra + order_by` in the snippet above.
+
+    MyModel.objects.filter_o(field_name__similar='whatever')
+
+So, this will return every similar `MyModel` instance with a `field_name` *similar*
+to `'whatever'` and sorted by the distance ot each intance's `field_name` value to target `'whatever'`. In addition, an extra field `field_name_distance` is added
+to each item in the queryset.
+
+
 
 Development
 -----------


### PR DESCRIPTION
I've added a custom manager that mimics the example "filter by similarity" + "sort by similarity distance". 

This should include tests but in the meanwhile, I show you a working example:

``` python

In [20]: d
Out[20]: u'Alimento balanceado carne 9 lives 500 gr'

In [21]: [(p.id, p.descripcion) for p in Producto.objects.filter(descripcion__similar=d)]    # standar filter. not sorted
Out[21]: 
[(1067, u'Alimento balanceado carne 9 lives 1 kg'),
 (1068, u'Alimento balanceado carne 9 lives 3 kg'),
 (1069, u'Alimento balanceado carne 9 lives 500 gr'),
 (1070, u'Alimento balanceado salmon 9 lives 1 kg'),
 (1071, u'Alimento carne whiskas 500 gr'),
 (1076, u'Alimento gato carne 9 lives 1 kg'),
 (1077, u'Alimento gato carne 9 lives 500 gr'),
 (1080, u'Alimento gato carne lata whiskas 340 gr'),
 (1082, u'Alimento gato carne mizzi cat 500 gr'),
 (1095, u'Alimento gato pescado mizzi cat 500 gr'),
 (1098, u'Alimento gato pescado raza 500 gr'),
 (1107, u'Alimento gato salmon 9 lives 3 kg'),
 (1108, u'Alimento gato salmon 9 lives 500 gr'),
 (1124, u'Alimento gatitos carne leche whiskas 500 gr'),
 (1136, u'Alimento bal carne-veg tiernitos 1,5 kg'),
 (1137, u'Alimento balanceado perro alimix 10 kg'),
 (1138, u'Alimento balanceado perro carne tiernitos 3kg'),
 (1139, u'Alimento balanceado perros alimix 3 kg'),
 (1140, u'Alimento carne adu lata pedigree 340 gr'),
 (1255, u'Alimento carne cach lata pedigree 340 gr'),
 (10355,
  u'Selecci\xf3n Carne y Vegetales. Alimento balanceado para perros. 1.5 Kg'),
 (11460,
  u'Alimento a base de cacao. Alimentos libre de gluten (Sobre 500 Grs)')]

In [22]: [(p.id, p.descripcion, p.descripcion_distance) for p in Producto.objects.filter_o(descripcion__similar=d)]
Out[22]: 
[(1069, u'Alimento balanceado carne 9 lives 500 gr', 1.0),
 (1067, u'Alimento balanceado carne 9 lives 1 kg', 0.73913),
 (1068, u'Alimento balanceado carne 9 lives 3 kg', 0.73913),
 (1077, u'Alimento gato carne 9 lives 500 gr', 0.681818),
 (1070, u'Alimento balanceado salmon 9 lives 1 kg', 0.528302),
 (1076, u'Alimento gato carne 9 lives 1 kg', 0.489796),
 (1108, u'Alimento gato salmon 9 lives 500 gr', 0.470588),
 (1071, u'Alimento carne whiskas 500 gr', 0.44898),
 (1138, u'Alimento balanceado perro carne tiernitos 3kg', 0.42623),
 (1082, u'Alimento gato carne mizzi cat 500 gr', 0.423077),
 (1124, u'Alimento gatitos carne leche whiskas 500 gr', 0.377049),
 (1139, u'Alimento balanceado perros alimix 3 kg', 0.357143),
 (1137, u'Alimento balanceado perro alimix 10 kg', 0.357143),
 (10355,
  u'Selecci\xf3n Carne y Vegetales. Alimento balanceado para perros. 1.5 Kg',
  0.35443),
 (1095, u'Alimento gato pescado mizzi cat 500 gr', 0.344828),
 (1098, u'Alimento gato pescado raza 500 gr', 0.327273),
 (1107, u'Alimento gato salmon 9 lives 3 kg', 0.321429),
 (1080, u'Alimento gato carne lata whiskas 340 gr', 0.316667),
 (1140, u'Alimento carne adu lata pedigree 340 gr', 0.311475),
 (1255, u'Alimento carne cach lata pedigree 340 gr', 0.311475),
 (1136, u'Alimento bal carne-veg tiernitos 1,5 kg', 0.306452),
 (11460,
  u'Alimento a base de cacao. Alimentos libre de gluten (Sobre 500 Grs)',
  0.3)]
```
