### PR TITLE
Fix % bug

### DIFF
--- a/djorm_pgtrgm/__init__.py
+++ b/djorm_pgtrgm/__init__.py
@@ -70,7 +70,6 @@ if backend_allowed:
 class SimilarQuerySet(QuerySet):
 
     def filter_o(self, **kwargs):
-        import ipdb; ipdb.set_trace()
         qs = super(SimilarQuerySet, self).filter(**kwargs)
         for lookup, query in kwargs.items():
             query = query.replace('%', '%%')

--- a/djorm_pgtrgm/__init__.py
+++ b/djorm_pgtrgm/__init__.py
@@ -70,8 +70,10 @@ if backend_allowed:
 class SimilarQuerySet(QuerySet):
 
     def filter_o(self, **kwargs):
+        import ipdb; ipdb.set_trace()
         qs = super(SimilarQuerySet, self).filter(**kwargs)
         for lookup, query in kwargs.items():
+            query = query.replace('%', '%%')
             if lookup.endswith('__similar'):
                 field = lookup.replace('__similar', '')
                 select = {'%s_distance' % field: "similarity(%s, '%s')" % (field, query)}


### PR DESCRIPTION
if you try to order a by similar distance against a query with the symbol `%` in it, an `IndexError` is raised. 
I find this ticky error through Sentry, here: https://github.com/mgaitan/preciosa/issues/190

reference http://python.6.x6.nabble.com/Escape-percent-sign-in-QuerySet-extra-td4998097.html