### PR TITLE
distance is the INVERSE of similarity

### DIFF
--- a/djorm_pgtrgm/__init__.py
+++ b/djorm_pgtrgm/__init__.py
@@ -74,8 +74,8 @@ class SimilarQuerySet(QuerySet):
         for lookup, query in kwargs.items():
             if lookup.endswith('__similar'):
                 field = lookup.replace('__similar', '')
-                select = {'%s_distance' % field: "similarity(%s, '%s')" % (field, query)}
-                qs = qs.extra(select=select).order_by('-%s_distance' % field)
+                select = {'%s_similarity' % field: "similarity(%s, '%s')" % (field, query)}
+                qs = qs.extra(select=select).order_by('-%s_similarity' % field)
         return qs
 
 


### PR DESCRIPTION
Naming the annotated field for the similarity score a "distance" is confusing and wrong. The more similar things are the closer they are, not the more distant they are. This is why similarity must be sorted in decreasing order (the minus sign in the order_by filter) for the best match to be at the start of the list.  "Distance" is the inverse (or negative, or opposite) of "similarity".
