### PR TITLE
Override SimilarManager.filter so that `filter`s can precede `filter_o`s

### DIFF
--- a/djorm_pgtrgm/__init__.py
+++ b/djorm_pgtrgm/__init__.py
@@ -80,9 +80,11 @@ class SimilarQuerySet(QuerySet):
 
 
 class SimilarManager(models.Manager):
+    def filter(self, *args, **kwargs):
+        return self.get_queryset().filter(*args, **kwargs)
 
     def get_queryset(self):
         return SimilarQuerySet(self.model, using=self._db)
 
-    def filter_o(self, **kwargs):
-        return self.get_queryset().filter_o(**kwargs)
+    def filter_o(self, *args, **kwargs):
+        return self.get_queryset().filter_o(*args, **kwargs)


### PR DESCRIPTION
Also, add *args to both filter() and filter_o() methods in case Django ORM begins to accept non-keyword (positional) arguments in filter() in future versions.
