### PR TITLE
ImportError instead of NameError for Django < 1.7

### DIFF
--- a/djorm_pgtrgm/__init__.py
+++ b/djorm_pgtrgm/__init__.py
@@ -6,7 +6,7 @@ from django.db.models.query import QuerySet
 try:
     # Django 1.7 API for custom lookups
     from django.db.models import Lookup
-except NameError:
+except ImportError:
     from django.db.models.sql.constants import QUERY_TERMS
 from django.contrib.gis.db.models.sql.query import ALL_TERMS
 


### PR DESCRIPTION
When the app is used with a Django version < 1.7 we have to check for an ImportError instead of a NameError.

Thank you for this useful Django app!
