### PR TITLE
Pass query value as param to `QuerySet.extra`

### DIFF
--- a/djorm_pgtrgm/models.py
+++ b/djorm_pgtrgm/models.py
@@ -91,8 +91,14 @@ class SimilarQuerySet(QuerySet):
             query = query.replace('%', '%%')
             if lookup.endswith('__similar'):
                 field = lookup.replace('__similar', '')
-                select = {'%s_distance' % field: "similarity(%s, '%s')" % (field, query)}
-                qs = qs.extra(select=select).order_by('-%s_distance' % field)
+                select = {
+                    '{}_distance'.format(field):
+                        'similarity({}, %s)'.format(field)
+                }
+                qs = qs.extra(
+                    select=select,
+                    select_params=[query]
+                ).order_by('-{}_distance'.format(field))
         return qs
 
 


### PR DESCRIPTION
Passing the query value as a parameter to `QuerySet.extra` instead of manually interpolating with string formatting prevents SQL injection and properly escapes the query value (for example single quotes). This is the recommended way of passing in parameters to extra select clauses, as per [Django's documentation](https://docs.djangoproject.com/en/1.9/ref/models/querysets/#extra).